### PR TITLE
fix: remove user stories and some unused css

### DIFF
--- a/timestamp-microservice/README.md
+++ b/timestamp-microservice/README.md
@@ -1,11 +1,1 @@
-# Timestamp Microservice
-
-## User stories:
-
-1. The API endpoint is `GET [project_url]/api/timestamp/:date_string?`
-1. A date string is valid if can be successfully parsed by `new Date(date_string)` (JS). Note that the unix timestamp needs to be an **integer** (not a string) specifying **milliseconds**. In our test we will use date strings compliant with ISO-8601 (e.g. `"2016-11-20"`) because this will ensure an UTC timestamp.
-1. If the date string is **empty** it should be equivalent to trigger `new Date()`, i.e. the service uses the current timestamp.
-1. If the date string is **valid** the api returns a JSON having the structure 
-`{"unix": <date.getTime()>, "utc" : <date.toUTCString()> }`
-e.g. `{"unix": 1479663089000 ,"utc": "Sun, 20 Nov 2016 17:31:29 GMT"}`.
-1. If the date string is **invalid** the api returns a JSON having the structure `{"error" : "Invalid Date" }`.
+# [Timestamp Microservice](https://www.freecodecamp.org/learn/apis-and-microservices/apis-and-microservices-projects/timestamp-microservice)

--- a/timestamp-microservice/README.md
+++ b/timestamp-microservice/README.md
@@ -1,1 +1,0 @@
-# [Timestamp Microservice](https://www.freecodecamp.org/learn/apis-and-microservices/apis-and-microservices-projects/timestamp-microservice)

--- a/timestamp-microservice/public/style.css
+++ b/timestamp-microservice/public/style.css
@@ -18,6 +18,10 @@ h3 {
   margin-top: 30px;
 }
 
+hr {
+	margin: 25px;
+}
+
 .footer {
 	margin-top: 40px;
 }

--- a/timestamp-microservice/public/style.css
+++ b/timestamp-microservice/public/style.css
@@ -28,18 +28,13 @@ code {
   color: black;
   background-color: #fff;
 }
-ol {
-	list-style-position: outside;
-}
+
 ul {
 	list-style-type: none;
 }
 
 li {
   margin-bottom: 0.5em;
-}
-.user-stories li {
-  margin-bottom: 1em;
 }
 
 a {

--- a/timestamp-microservice/views/index.html
+++ b/timestamp-microservice/views/index.html
@@ -1,34 +1,32 @@
 <!DOCTYPE html>
 
 <html>
+  <head>
+    <title>Timestamp Microservice | freecodecamp.org</title>
+    <link rel="shortcut icon" href="https://cdn.freecodecamp.org/universal/favicons/favicon-32x32.png" type="image/x-icon"/>
+    <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css">
+    <link href="style.css" rel="stylesheet" type="text/css">
+  </head>
 
-   <head>
-      <title>Timestamp Microservice</title>
-      <link rel="shortcut icon" href="https://cdn.hyperdev.com/us-east-1%3A52a203ff-088b-420f-81be-45bf559d01b1%2Ffavicon.ico" type="image/x-icon"/>
-      <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css">
-      <link href="style.css" rel="stylesheet" type="text/css">
-   </head>
+  <body>
+    <h1>Timestamp Microservice</h1>
+    <hr />
+    <div class="container">
+      <h3>Example Usage:</h3>
+      <ul>
+        <li><a href="api/timestamp/2015-12-25">[project url]/api/timestamp/2015-12-25</a></li>
+        <li><a href="api/timestamp/1451001600000">[project url]/api/timestamp/1451001600000</a></li>
+      </ul>
 
-   <body>
-
-      <div class="container">
-        <h2>API Project: Timestamp Microservice</h2>
-        <h3>Example Usage:</h3>
-        <ul>
-          <li><a href="api/timestamp/2015-12-25">[project url]/api/timestamp/2015-12-25</a></li>
-          <li><a href="api/timestamp/1451001600000">[project url]/api/timestamp/1451001600000</a></li>
-        </ul>
-
-        <h3>Example Output:</h3>
-        <p>
-          <code>{"unix":1451001600000, "utc":"Fri, 25 Dec 2015 00:00:00 GMT"}</code>
-        </p>
-      </div>
-      <div class="footer">
-        <p>
-          By <a href="https://www.freecodecamp.org/">freeCodeCamp</a>
-        </p>
-      </div>
-   </body>
-
+      <h3>Example Output:</h3>
+      <p>
+        <code>{"unix":1451001600000, "utc":"Fri, 25 Dec 2015 00:00:00 GMT"}</code>
+      </p>
+    </div>
+    <div class="footer">
+      <p>
+        By <a href="https://www.freecodecamp.org/">freeCodeCamp.org</a>
+      </p>
+    </div>
+  </body>
 </html>


### PR DESCRIPTION
Related to: https://github.com/freeCodeCamp/freeCodeCamp/issues/39721

The unused css was used in the index.html file - the user stories were already removed from there so the css wasn't being used anymore. 

Wait until we have added user stories to learn to merge this.