### PR TITLE
fix: remove readme and unused css

### DIFF
--- a/request-header-parser-microservice/README.md
+++ b/request-header-parser-microservice/README.md
@@ -1,7 +1,0 @@
-# Request Header Parser Microservice
-
-## User stories:
-
-1. Your IP address should be returned in the `ipaddress` key.
-1. Your preferred language should be returned in the `language` key.
-1. Your software should be returned in the `software` key.

--- a/request-header-parser-microservice/public/style.css
+++ b/request-header-parser-microservice/public/style.css
@@ -28,18 +28,13 @@ code {
   color: black;
   background-color: #fff;
 }
-ol {
-	list-style-position: outside;
-}
+
 ul {
 	list-style-type: none;
 }
 
 li {
   margin-bottom: 0.5em;
-}
-.user-stories li {
-  margin-bottom: 1em;
 }
 
 a {


### PR DESCRIPTION
Related to: https://github.com/freeCodeCamp/freeCodeCamp/issues/39721

The css was used for elements that described the user stories in the index.html file - those elements were removed with another PR

Wait until we have added user stories to learn to merge this.