### PR TITLE
fix: Changed .env variable name to match one used in the actual project code

### DIFF
--- a/issue-tracker/sample.env
+++ b/issue-tracker/sample.env
@@ -1,3 +1,3 @@
 PORT=
-DB_URI=
+DB=
 # NODE_ENV=test


### PR DESCRIPTION
Discovered this small issue when testing out the example Issue Tracker project locally.  The code references `process.env.DB` instead of `DB_URI`, so I changed the `sample.env` file to reflect what the variable name should actually be.