### PR TITLE
fix: Show correct return type for price in example usage

### DIFF
--- a/stock-price-checker/views/index.html
+++ b/stock-price-checker/views/index.html
@@ -23,8 +23,8 @@
     <code>/api/stock-prices?stock=GOOG&amp;stock=MSFT</code><br>
     <code>/api/stock-prices?stock=GOOG&amp;stock=MSFT&amp;like=true</code><br>
     <h3>Example return:</h3>
-    <code>{"stockData":{"stock":"GOOG","price":"786.90","likes":1}}</code><br>
-    <code>{"stockData":[{"stock":"MSFT","price":"62.30","rel_likes":-1},{"stock":"GOOG","price":"786.90","rel_likes":1}]}</code>
+    <code>{"stockData":{"stock":"GOOG","price":786.90,"likes":1}}</code><br>
+    <code>{"stockData":[{"stock":"MSFT","price":62.30,"rel_likes":-1},{"stock":"GOOG","price":786.90,"rel_likes":1}]}</code>
   </div>
   <hr>
   <div id="testui">


### PR DESCRIPTION
The requirement for `price` is for it to be a number, so the example return shown should not be a string. I did this edit directly in the file, but hopefully, that's OK.

As a separate issue, we also need to change the User story https://github.com/freeCodeCamp/freeCodeCamp/pull/40218#pullrequestreview-538375840