### PR TITLE
fix: clear target cell in puzzle before value try

### DIFF
--- a/sudoku-solver/controllers/sudoku-solver.js
+++ b/sudoku-solver/controllers/sudoku-solver.js
@@ -66,6 +66,12 @@ class SudokuSolver {
     return [false, row, col];
   }
 
+  clearTargetCellInPuzzle(puzzleString, row, col) {
+    this.importString(puzzleString);
+    this._puzzle[row][col] = 0;
+    return this.exportString();
+  }
+
   importString(input) {
     this._puzzle = [];
     for (let row = 0; row < WIDTH; row++) {

--- a/sudoku-solver/routes/api.js
+++ b/sudoku-solver/routes/api.js
@@ -35,9 +35,11 @@ module.exports = function (app) {
         return res.json({error: 'Invalid coordinate'})
       }
 
-      let rowCheck = solver.checkRowPlacement(req.body.puzzle, row, value);
-      let colCheck = solver.checkColPlacement(req.body.puzzle, col, value);
-      let regionCheck = solver.checkRegionPlacement(req.body.puzzle,
+      const puzzle = solver.clearTargetCellInPuzzle(req.body.puzzle, row, col);
+
+      let rowCheck = solver.checkRowPlacement(puzzle, row, value);
+      let colCheck = solver.checkColPlacement(puzzle, col, value);
+      let regionCheck = solver.checkRegionPlacement(puzzle,
         row - row % 3,
         col - col % 3,
         value);


### PR DESCRIPTION
* Changes handling of check for value that already is in puzzle under checked coordinate.
* Project with changes tested on repl.it and against project page tests on local fork of freeCodeCamp.

Related to https://github.com/freeCodeCamp/freeCodeCamp/issues/40359 and https://github.com/freeCodeCamp/freeCodeCamp/pull/41225