### PR TITLE
fix: remove not used part of log url description

### DIFF
--- a/exercise-tracker/views/index.html
+++ b/exercise-tracker/views/index.html
@@ -29,7 +29,7 @@
         <strong>GET user's exercise log: </strong>
         <code>GET /api/users/:_id/logs?[from][&amp;to][&amp;limit]</code>
       </p>
-      <p><strong>{ }</strong> = required, <strong>[ ]</strong> = optional</p>
+      <p><strong>[ ]</strong> = optional</p>
       <p><strong>from, to</strong> = dates (yyyy-mm-dd); <strong>limit</strong> = number</p>
     </div>
     <script>


### PR DESCRIPTION
- Removes part of exercise log description that's not relevant in new version of url route.
- Related to https://github.com/freeCodeCamp/freeCodeCamp/pull/41786 and https://github.com/freeCodeCamp/boilerplate-project-exercisetracker/pull/51

Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
