### PR TITLE
fix: hide fields

### DIFF
--- a/anonymous-message-board/controllers/replyHandler.js
+++ b/anonymous-message-board/controllers/replyHandler.js
@@ -11,10 +11,12 @@ function ReplyHandler() {
       const collection = db.collection(board);
       collection.find({_id: new ObjectId(req.query.thread_id)},
       {
-        reported: 0,
-        delete_password: 0,
-        "replies.delete_password": 0,
-        "replies.reported": 0
+        projection: {
+          reported: 0,
+          delete_password: 0,
+          "replies.delete_password": 0,
+          "replies.reported": 0
+        }
       })
       .toArray((err, doc) => {
         res.json(doc[0]);

--- a/anonymous-message-board/controllers/threadHandler.js
+++ b/anonymous-message-board/controllers/threadHandler.js
@@ -12,10 +12,12 @@ function ThreadHandler() {
       collection.find(
         {},
         {
-          reported: 0,
-          delete_password: 0,
-          "replies.delete_password": 0,
-          "replies.reported": 0
+          projection: {
+            reported: 0,
+            delete_password: 0,
+            "replies.delete_password": 0,
+            "replies.reported": 0
+          }
         })
       .sort({bumped_on: -1})
       .limit(10)


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This ties in to https://github.com/freeCodeCamp/freeCodeCamp/pull/41932.

The database queries were already attempting to hide the `reported` and `delete_password` fields but the syntax was incorrect so the fields were still being fetched. 

<!-- Feel free to add any additional description of changes below this line -->
