### PR TITLE
fix: configure renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,16 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "local>freeCodeCamp/renovate-config"
+  "labels": ["renovate"],
+  "extends": ["config:base"],
+  "branchConcurrentLimit": 20,
+  "dependencyDashboard": true,
+  "major": {
+    "dependencyDashboardApproval": true
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
Ideally we want to use https://github.com/freeCodeCamp/renovate-config
but that appears to be failing (not sure why).

Hopefully, in the interim, this should work.
