### PR TITLE
fix: image search abstraction layer recent searches

### DIFF
--- a/apps/image-search-abstraction-layer/api.js
+++ b/apps/image-search-abstraction-layer/api.js
@@ -44,16 +44,15 @@ module.exports = function(app) {
       var collection = db.collection('searches');
 
       collection.find( {}, { _id:0 } ).toArray(function(err, result) {
-        if(err) {
-          return res.send(err);
-        } else if (result.length) {
+        db.close();
+        if (err) return res.send(err);
+        
+        if (result.length) {
           return res.json(result);
         } else {
           return res.send('No Documents Found.');        
         }
       });
-
-      db.close();
     });
   }
 };

--- a/apps/image-search-abstraction-layer/api.js
+++ b/apps/image-search-abstraction-layer/api.js
@@ -2,9 +2,8 @@ var googleSearch = require('google-images');
 var moment = require('moment');
 var mongo = require('mongodb').MongoClient;
 
-module.exports = function(app) {
-
-  app.get('/', function(req,res) {
+module.exports = function (app) {
+  app.get('/', function (req, res) {
     console.log("Redirected to 'index.html'");
     return res.sendFile('public/index.html', { root: __dirname });
   });
@@ -17,22 +16,25 @@ module.exports = function(app) {
     var pages = req.query.page;
     var sizes = req.query.size;
     var client = new googleSearch(process.env.CSEID, process.env.APIKEY);
-    
+
     mongo.connect(process.env.MONGO_URI, function (err, db) {
       if (err) throw err;
       console.log('Connected to mongoDB');
-      
+
       var collection = db.collection('searches');
       var time = new Date();
       time /= 1000;
 
-      collection.insert({'searchQuery': searchQuery, 'timeSearched': moment.unix(time).format('MMMM Do YYYY, h:mm:ss a')});    
+      collection.insert({
+        searchQuery: searchQuery,
+        timeSearched: moment.unix(time).format('MMMM Do YYYY, h:mm:ss a'),
+      });
       db.close();
     });
 
-    client.search(searchQuery, {size: sizes, page: pages}).then(images => {
-      return res.json({images});
-     });
+    client.search(searchQuery, { size: sizes, page: pages }).then((images) => {
+      return res.json({ images });
+    });
   }
 
   function getRecent(req, res) {
@@ -40,17 +42,17 @@ module.exports = function(app) {
       var db = client.db();
       if (err) throw err;
       console.log('Connection Established');
-      
+
       var collection = db.collection('searches');
 
-      collection.find( {}, { _id:0 } ).toArray(function(err, result) {
+      collection.find({}, { _id: 0 }).toArray(function (err, result) {
         db.close();
         if (err) return res.send(err);
-        
+
         if (result.length) {
           return res.json(result);
         } else {
-          return res.send('No Documents Found.');        
+          return res.send('No Documents Found.');
         }
       });
     });

--- a/apps/image-search-abstraction-layer/api.js
+++ b/apps/image-search-abstraction-layer/api.js
@@ -17,7 +17,8 @@ module.exports = function (app) {
     var sizes = req.query.size;
     var client = new googleSearch(process.env.CSEID, process.env.APIKEY);
 
-    mongo.connect(process.env.MONGO_URI, function (err, db) {
+    mongo.connect(process.env.MONGO_URI, function (err, client) {
+      var db = client.db();
       if (err) throw err;
       console.log('Connected to mongoDB');
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Addresses https://github.com/freeCodeCamp/freeCodeCamp/issues/43518

<!-- Feel free to add any additional description of changes below this line -->
The main fix is moving `db.close()` inside the `.toArray()` method in the `getRecent` function.

All the other changes are cosmetic.