### PR TITLE
fix: pin all dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
   "major": {
     "dependencyDashboardApproval": true
   },
+  "rangeStrategy": "pin",
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],


### PR DESCRIPTION
I think we want to do this, since we want reproducibility (exactly the same versions in CI as in production), not flexibility.

@nhcarrigan I noticed https://github.com/freeCodeCamp/demo-projects/pull/102 going in and figured pinning is probably the way to go.