### PR TITLE
fix: avoid endless recursion

### DIFF
--- a/apps/sudoku-solver/controllers/sudoku-solver.js
+++ b/apps/sudoku-solver/controllers/sudoku-solver.js
@@ -4,6 +4,7 @@ const HEIGHT = 9;
 class SudokuSolver {
   constructor() {
     this._puzzle = [];
+    this._recursions = 0;
   }
 
   static validInput(input) {
@@ -101,6 +102,7 @@ class SudokuSolver {
     this.importString(puzzleString);
     // Check if the puzzle contains any empty squares
     if(puzzleString.match(/\./gi)) {
+      this._recursions = 0;
       // If so, use the solver.
       return this.solveSudoku(this._puzzle)
     } else {
@@ -194,6 +196,15 @@ class SudokuSolver {
   // all unassigned locations in such a way to meet the requirements
   // for Sudoku solution (non-duplication across rows, columns, and boxes)
   solveSudoku(grid) {
+    this._recursions++;
+    console.log(this._recursions);
+    // Tested the recursion count for the "hardest sudoku" puzzle
+    // Puzzle was fetched from https://www.conceptispuzzles.com/index.aspx?uri=info/article/424
+    // Recursion count was 49559 - rounded to 50000 for nice number + a bit of buffer.
+    // Anything exceeding this should be an unsolvable puzzle.
+    if (this._recursions > 50000) {
+      return false;
+    }
     // If the sudoku grid has been filled, we are done
     let [row, col] = this.getUnassignedLocation(grid)
     if (row === 10 || col === 10) {

--- a/apps/sudoku-solver/controllers/sudoku-solver.js
+++ b/apps/sudoku-solver/controllers/sudoku-solver.js
@@ -197,7 +197,6 @@ class SudokuSolver {
   // for Sudoku solution (non-duplication across rows, columns, and boxes)
   solveSudoku(grid) {
     this._recursions++;
-    console.log(this._recursions);
     // Tested the recursion count for the "hardest sudoku" puzzle
     // Puzzle was fetched from https://www.conceptispuzzles.com/index.aspx?uri=info/article/424
     // Recursion count was 49559 - rounded to 50000 for nice number + a bit of buffer.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
In the current state, the recursion get stuck in a loop if an unsolvable puzzle string is submitted. @ojeytonwilliams and I discussed an approach to fixing this with an arbitrary timeout, but after further thought I decided counting the recursive calls might be better.

A quick Google search gave me the "world's hardest sudoku", which the solver took 49000+ recursive calls to solve. By counting and capping the recursive calls at 50000, this PR will add an assumption that additional calls mean the puzzle is unsolvable and back out of the recursion.

Passing an unsolvable string with this change no longer locks up the server, but instead properly displays "puzzle cannot be solved" in the front end. 