### PR TITLE
Only accept 1-9 for /api/check value input

### DIFF
--- a/apps/sudoku-solver/routes/api.js
+++ b/apps/sudoku-solver/routes/api.js
@@ -26,7 +26,7 @@ module.exports = function (app) {
       }
 
       let value = parseInt(req.body.value);
-      if(!Number.isInteger(value) || value < 0 || value > 9) {
+      if(!Number.isInteger(value) || value < 1 || value > 9) {
         return res.json({ error: 'Invalid value' });
       }
 


### PR DESCRIPTION
Shows the correct response when a user attempts to submit `value=0` to `/api/check`.

### Sample Request
```
curl -X POST https://sudoku-solver.freecodecamp.rocks/api/check 
   -H "Content-Type: application/x-www-form-urlencoded"
   -d 'puzzle=.................................................................................&coordinate=A1&value=0' 
```

### Current response:
```json
{
    "valid": false,
    "conflict": [
        "row",
        "column",
        "region"
    ]
}
```

### Response with this change:
```json
{
    "error": "Invalid value"
}
```


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
