### PR TITLE
fix: heat map axes affected by local time

### DIFF
--- a/apps/heat-map/public/script.js
+++ b/apps/heat-map/public/script.js
@@ -208,7 +208,7 @@ function callback(data) {
     .tickFormat(function (month) {
       var date = new Date(0);
       date.setUTCMonth(month);
-      var format = d3.timeFormat('%B');
+      var format = d3.utcFormat('%B');
       return format(date);
     })
     .tickSize(10, 1);
@@ -253,7 +253,7 @@ function callback(data) {
     .tickFormat(function (year) {
       var date = new Date(0);
       date.setUTCFullYear(year);
-      var format = d3.timeFormat('%Y');
+      var format = d3.utcFormat('%Y');
       return format(date);
     })
     .tickSize(10, 1);
@@ -389,7 +389,7 @@ function callback(data) {
       var date = new Date(d.year, d.month);
       var str =
         "<span class='date'>" +
-        d3.timeFormat('%Y - %B')(date) +
+        d3.utcFormat('%Y - %B')(date) +
         '</span>' +
         '<br />' +
         "<span class='temperature'>" +


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/47073

---

- Depending on the local time axes can start on the different value (see occurrences in the linked issue). `timeFormat` method interprets data as being in the local time, `utcFormat` uses _Coordinated Universal Time (UTC)_ for that.
- The third occurrence `timeFormat('%Y - %B')` did not seem to impact tests, but I've changed it for consistency.
- Example with applied changes can be found at https://codepen.io/sanityto/full/gOKJQae