### PR TITLE
fix(javascript-calculator): adjust minus unicode, add noreferrer

### DIFF
--- a/apps/javascript-calculator/client/index.jsx
+++ b/apps/javascript-calculator/client/index.jsx
@@ -60,7 +60,7 @@ class Calculator extends React.Component {
       expression = expression
         .replace(/x/g, '*')
         .replace(/-/g, '-')
-        .replace('--', '+0+0+0+0+0+0+');
+        .replace('--', '-');
       let answer = Math.round(1000000000000 * eval(expression)) / 1000000000000;
       this.setState({
         currentVal: answer.toString(),
@@ -68,9 +68,8 @@ class Calculator extends React.Component {
           expression
             .replace(/\*/g, '⋅')
             .replace(/-/g, '-')
-            .replace('+0+0+0+0+0+0+', '-')
-            .replace(/(x|\/|\+)‑/, '$1-')
-            .replace(/^‑/, '-') +
+            .replace(/(x|\/|\+)-/, '$1-')
+            .replace(/^-/, '-') +
           '=' +
           answer,
         prevVal: answer,

--- a/apps/javascript-calculator/client/index.jsx
+++ b/apps/javascript-calculator/client/index.jsx
@@ -12,9 +12,9 @@ const projectName = 'javascript-calculator';
 // coded by @no-stack-dub-sack (github) / @no_stack_sub_sack (codepen)
 
 // VARS:
-const isOperator = /[x/+‑]/,
-  endsWithOperator = /[x+‑/]$/,
-  endsWithNegativeSign = /\d[x/+‑]{1}‑$/,
+const isOperator = /[x/+-]/,
+  endsWithOperator = /[x+-/]$/,
+  endsWithNegativeSign = /\d[x/+-]{1}-$/,
   clearStyle = { background: '#ac3939' },
   operatorStyle = { background: '#666666' },
   equalsStyle = {
@@ -59,7 +59,7 @@ class Calculator extends React.Component {
       }
       expression = expression
         .replace(/x/g, '*')
-        .replace(/‑/g, '-')
+        .replace(/-/g, '-')
         .replace('--', '+0+0+0+0+0+0+');
       let answer = Math.round(1000000000000 * eval(expression)) / 1000000000000;
       this.setState({
@@ -67,8 +67,8 @@ class Calculator extends React.Component {
         formula:
           expression
             .replace(/\*/g, '⋅')
-            .replace(/-/g, '‑')
-            .replace('+0+0+0+0+0+0+', '‑-')
+            .replace(/-/g, '-')
+            .replace('+0+0+0+0+0+0+', '-')
             .replace(/(x|\/|\+)‑/, '$1-')
             .replace(/^‑/, '-') +
           '=' +
@@ -97,7 +97,7 @@ class Calculator extends React.Component {
             (endsWithNegativeSign.test(formula + value) ? formula : prevVal) +
             value
         });
-      } else if (value !== '‑') {
+      } else if (value !== '-') {
         this.setState({
           formula: prevVal + value
         });
@@ -195,7 +195,7 @@ class Calculator extends React.Component {
         <div className='author'>
           {' '}
           Designed and Coded By <br />
-          <a href='https://goo.gl/6NNLMG' target='_blank'>
+          <a href='https://goo.gl/6NNLMG' target='_blank' rel='noreferrer'>
             Peter Weinberg
           </a>
         </div>
@@ -246,9 +246,9 @@ class Buttons extends React.Component {
           id='subtract'
           onClick={this.props.operators}
           style={operatorStyle}
-          value='‑'
+          value='-'
         >
-          ‑
+          -
         </button>
         <button id='four' onClick={this.props.numbers} value='4'>
           4


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x ] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)


<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Partially addresses [#49045](https://github.com/freeCodeCamp/freeCodeCamp/issues/49045)

<!-- Feel free to add any additional description of changes below this line -->

I included the closing number for issue 49045 because while working on it, I could not replicate that specific issue. In the process, I discovered that the minus operator was showing as a zero.  I changed the character based on the warning and has seemed to fix the issue. 

Also was receiving a warning due to missing rel-tag, so I included that as well.  

<img width="806" alt="Screenshot 2023-02-14 at 12 00 08 AM" src="https://user-images.githubusercontent.com/99623500/218915977-0c9534cc-8f38-4b81-bf33-ca2438599e03.png">


![Screenshot 2023-02-14 at 7 35 20 PM](https://user-images.githubusercontent.com/99623500/218916001-56d77977-01d8-44f3-873a-b496a6cab4ed.png)

![Screenshot 2023-02-14 at 7 31 32 PM](https://user-images.githubusercontent.com/99623500/218916015-462e3c41-2df7-410d-bae6-0d05aa180f45.png)
