### PR TITLE
fix(javascript-calculator): removing +0 and -0 from the expression displayed on calculator. 

### DIFF
--- a/apps/javascript-calculator/client/index.jsx
+++ b/apps/javascript-calculator/client/index.jsx
@@ -54,23 +54,31 @@ class Calculator extends React.Component {
   handleEvaluate() {
     if (!this.state.currentVal.includes('Limit')) {
       let expression = this.state.formula;
+      let zeroOperationPattern = new RegExp(/[+-]+0/g)
+
+      expression = expression
+      .replace(/x/g, '*')
+      .replace(/‑/g, '-')
+
       while (endsWithOperator.test(expression)) {
         expression = expression.slice(0, -1);
       }
-      expression = expression
-        .replace(/x/g, '*')
-        .replace(/‑/g, '-')
-        .replace('--', '+0+0+0+0+0+0+');
-      let answer = Math.round(1000000000000 * eval(expression)) / 1000000000000;
+      
+      let zeroPatternMatches = expression.match(zeroOperationPattern)
+      
+      if (zeroPatternMatches) {
+        zeroPatternMatches.forEach(match => expression = expression.replace(match, ''))
+      }
+  
+      let answer = eval(expression)
       this.setState({
         currentVal: answer.toString(),
         formula:
           expression
-            .replace(/\*/g, '⋅')
-            .replace(/-/g, '‑')
-            .replace('+0+0+0+0+0+0+', '‑-')
-            .replace(/(x|\/|\+)‑/, '$1-')
-            .replace(/^‑/, '-') +
+          .replace(/\*/g, '⋅')
+          .replace(/-/g, '‑')
+          .replace(/(x|\/|\+)‑/, '$1-')
+          .replace(/^‑/, '-') +
           '=' +
           answer,
         prevVal: answer,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Partially closes [#49045](https://github.com/freeCodeCamp/freeCodeCamp/issues/49045)

With the 6 trailing zeros gone, I think it's still useful to remove any arithmetic involving zeros. That way the expression looks cleaner and the fix can even handle cases where the user types `--0`. 
