### PR TITLE
fix: CORS for PokéAPI Proxy

### DIFF
--- a/apps/pokeapi-proxy/package-lock.json
+++ b/apps/pokeapi-proxy/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "axios": "1.6.0",
+        "cors": "2.8.5",
         "dotenv": "16.3.1",
         "express": "4.18.2",
         "node-cache": "5.1.2"
@@ -140,6 +141,18 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -481,6 +494,14 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/apps/pokeapi-proxy/package.json
+++ b/apps/pokeapi-proxy/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "axios": "1.6.0",
+    "cors": "2.8.5",
     "dotenv": "16.3.1",
     "express": "4.18.2",
     "node-cache": "5.1.2"

--- a/apps/pokeapi-proxy/server.mjs
+++ b/apps/pokeapi-proxy/server.mjs
@@ -1,11 +1,15 @@
 import 'dotenv/config';
 import express from 'express';
+import cors from 'cors';
 import { router as pokemonRouter } from './api/pokemon/pokemon.routes.mjs';
 const portNum = process.env.PORT || 3000;
 const app = express();
 
 // Serve static content and landing page
 app.use(express.static('public'));
+
+// CORS
+app.use(cors());
 
 app.get('/', (req, res) => {
   res.sendFile(__dirname + '/views/index.html');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
This PR sets up CORS for the PokéAPI proxy, which should allow people to use this proxy to work on the upcoming Pokémon Search App project locally.