### PR TITLE
fix: 25-5 clock Caddyfile workaround

### DIFF
--- a/scripts/create-caddyfile.js
+++ b/scripts/create-caddyfile.js
@@ -30,11 +30,19 @@ for (const serviceName in services) {
   if (serviceName === 'mongo' || serviceName === 'caddy') {
     continue;
   }
+
+  const exceptions = {
+    '25--5-clock': 'clock'
+  };
+  const subdomain = exceptions[serviceName]
+    ? exceptions[serviceName]
+    : serviceName;
   const target = `${serviceName}:${
     services[serviceName].ports[0].split(':')[1]
   }`;
+
   caddyfile += `
-${serviceName}.${process.env.DEMO_APPS_DOMAIN} {
+${subdomain}.${process.env.DEMO_APPS_DOMAIN} {
   reverse_proxy ${target}
 }
 `;

--- a/scripts/create-caddyfile.js
+++ b/scripts/create-caddyfile.js
@@ -31,12 +31,7 @@ for (const serviceName in services) {
     continue;
   }
 
-  const exceptions = {
-    '25--5-clock': 'clock'
-  };
-  const subdomain = exceptions[serviceName]
-    ? exceptions[serviceName]
-    : serviceName;
+  const subdomain = serviceName === '25--5-clock' ? 'clock' : serviceName;
   const target = `${serviceName}:${
     services[serviceName].ports[0].split(':')[1]
   }`;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/demo-projects/issues/535

<!-- Feel free to add any additional description of changes below this line -->
This adds an exception for the `25--5-clock` subdomain in the Caddyfile generator script to get around the bug we discovered some time ago where two consecutive numbers don't work as a subdomain for some reason.

This fix, along with the redirect on Cloudflare from `25--5-clock.freecodecamp.rocks` to `clock.freecodecamp.rocks`, should take care of the issue above where visiting `25--5-clock.freecodecamp.rocks` leads to an error page.