### PR TITLE
fix(a11y): make the input and button elements accessible

### DIFF
--- a/apps/pokemon-search-app/public/styles.css
+++ b/apps/pokemon-search-app/public/styles.css
@@ -73,6 +73,11 @@ label {
   align-self: center;
 }
 
+#search-input:focus-visible,
+#search-button:focus-visible {
+  outline: 3px solid #198eee;
+}
+
 #search-input {
   height: 40px;
   padding-left: 10px;
@@ -86,7 +91,6 @@ label {
   text-align: center;
   background-color: #7f21ab;
   color: #f5f6f7;
-  outline: none;
   border: none;
 }
 

--- a/apps/roman-numeral-converter/public/styles.css
+++ b/apps/roman-numeral-converter/public/styles.css
@@ -5,6 +5,7 @@
   --gray-75: #3b3b4f;
   --gray-85: #1b1b32;
   --gray-90: #0a0a23;
+  --blue-50: #198eee;
   --error: #a94442;
   --danger-color: #850000;
   --danger-background: #ffadad;
@@ -71,6 +72,11 @@ label {
   font-weight: bold;
 }
 
+input:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--blue-50);
+}
+
 input {
   display: block;
   font-size: 2.5rem;
@@ -82,12 +88,10 @@ input {
   color: white;
   background-color: var(--gray-90);
   border: 1px solid var(--gray-05);
-  outline: none;
   outline-style: none;
 }
 
 button {
-  outline: none;
   cursor: pointer;
   margin-top: 15px;
   text-decoration: none;

--- a/apps/roman-numeral-converter/public/styles.css
+++ b/apps/roman-numeral-converter/public/styles.css
@@ -88,7 +88,6 @@ input {
   color: white;
   background-color: var(--gray-90);
   border: 1px solid var(--gray-05);
-  outline-style: none;
 }
 
 button {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Partially addresses https://github.com/freeCodeCamp/freeCodeCamp/issues/52709.

<!-- Feel free to add any additional description of changes below this line -->
1. The `outline: none;` CSS property of the `button` element was removed so it will be keyboard-focusable and complying the [WCAG SC 2.1.1](https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html).
2. Also, removing `outline: none;` and `outline-style: none;` of `input` element and applying the custom outline styles to the `input` and `button` elements with using the `:focus-visible` pseudo-class so the outline will be sufficiently visible for people who is visually impaired or have low vision and complying the [WCAG SC 2.4.7](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html), with referencing the [technique G195](https://www.w3.org/WAI/WCAG21/Techniques/general/G195). After [investigation](https://webaim.org/resources/contrastchecker/), the contrast ratio between the background color and the outline style will be 3.15:1 or 3.19:1, so it will meet the [WCAG SC 1.4.11](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html).

The code was tested locally with windows 11 Home PC using Chrome, Firefox, Edge, and Brave browser.