### PR TITLE
fix: remove non-descriptive var named stuff

### DIFF
--- a/apps/american-british-translator/public/index.js
+++ b/apps/american-british-translator/public/index.js
@@ -4,7 +4,6 @@ const translateHandler = async () => {
   const errorArea = document.getElementById('error-msg');
   const translatedArea = document.getElementById('translated-sentence');
 
-  const stuff = { text: textArea.value, locale: localeArea.value };
   errorArea.innerText = '';
   translatedArea.innerText = '';
 
@@ -14,7 +13,7 @@ const translateHandler = async () => {
       Accept: 'application/json',
       'Content-type': 'application/json'
     },
-    body: JSON.stringify(stuff)
+    body: JSON.stringify({ text: textArea.value, locale: localeArea.value })
   });
 
   const parsed = await data.json();


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ x ] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This is a twin PR to one against the `boilerplate-project-american-british-english-translator` repo. 

The reason for this PR is because the variable name 'stuff' is not descriptive or semantic. Changing this will help campers reading the code follow along, and also make the codebase read more professionally.