### PR TITLE
feat: use tls internal for Caddy

### DIFF
--- a/scripts/create-caddyfile.js
+++ b/scripts/create-caddyfile.js
@@ -18,6 +18,7 @@ http:// {
 }
 
 www.freecodecamp.rocks {
+  tls internal
   handle /ping {
     respond "pong" 200
   }
@@ -38,6 +39,7 @@ for (const serviceName in services) {
 
   caddyfile += `
 ${subdomain}.${process.env.DEMO_APPS_DOMAIN} {
+  tls internal
   reverse_proxy ${target}
 }
 `;


### PR DESCRIPTION
This PR updates the Caddyfile script generator to use the `tls internal` directive with Caddy to allow for full SSL behaviour from Cloudflare. We used to use LE-based certificates but they are redundant since we use Cloudflare.
