### PR TITLE
fix: simplify protocol handling

### DIFF
--- a/apps/pokeapi-proxy/api/pokemon/pokemon.handlers.mjs
+++ b/apps/pokeapi-proxy/api/pokemon/pokemon.handlers.mjs
@@ -11,6 +11,8 @@ export const getPokemonEndpointResources = async (req, res, next) => {
       console.log(
         'Fetching all resources for the Pokémon endpoint from PokéAPI'
       );
+      const host = req.get('host');
+      const protocol = host.match(/localhost\:\d+/) ? 'http' : 'https';
       const { data } = await axios.get(
         `https://pokeapi.co/api/v2/pokemon/?limit=9000`
       );
@@ -20,12 +22,13 @@ export const getPokemonEndpointResources = async (req, res, next) => {
         count,
         results: results.map(obj => {
           const { name, url } = obj;
+
           return {
             id: Number(url.split('/').filter(Boolean).pop()),
             name,
             url: url.replace(
               'https://pokeapi.co/api/v2/',
-              `${req.protocol}://${req.get('host')}/api/`
+              `${protocol}://${host}/api/`
             )
           };
         })


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/demo-projects/issues/597

<!-- Feel free to add any additional description of changes below this line -->
This PR simplifies handling of the API resource protocol so resource links on the `/api/pokemon` endpoint only use HTTP when the project is running locally, and use HTTPS in all other cases.

I believe it's still possible for someone to set the headers to `localhost:<port>` when sending a request to the API, which would mean that the links at `/api/pokemon` would be HTTP rather than HTTPS, but I doubt it will be an issue for this project. At this point, learners should just be using `fetch()` without setting any headers.