### PR TITLE
fix(cash register): styles, allow large browser font sizes

### DIFF
--- a/apps/cash-register/public/styles.css
+++ b/apps/cash-register/public/styles.css
@@ -12,6 +12,7 @@
 body {
   background-color: var(--dark-blue);
   color: var(--light-gray);
+  min-width: 320px;
 }
 
 main {
@@ -98,10 +99,9 @@ label {
   display: flex;
   justify-content: space-around;
   border-radius: 35px 35px 0 0;
-  padding-top: 20px;
+  padding: 20px 0;
   background-color: #99c9ff;
-  height: 250px;
-  width: 325px;
+  min-height: 250px;
 }
 
 .btns-container {
@@ -142,7 +142,7 @@ label {
 .bottom-register {
   background-color: #99c9ff;
   height: 50px;
-  width: 325px;
+  width: 100%;
   margin-top: 10px;
 }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related: https://github.com/freeCodeCamp/freeCodeCamp/issues/55542

Updated the styles:

- Allow for large browser fonts without an overflow
- Avoid unnecessary text wrapping by giving it more width, but having a min width on body at 320px

---

I only tested this locally using the HTML/CSS, I didn't run the repo.
