### PR TITLE
fix: Remove innerHTML sink in Palindrome Checker

### DIFF
--- a/apps/palindrome-checker/public/script.js
+++ b/apps/palindrome-checker/public/script.js
@@ -14,13 +14,13 @@ const checkForPalindrome = input => {
   resultDiv.replaceChildren();
 
   const lowerCaseStr = input.replace(/[^A-Za-z0-9]/gi, '').toLowerCase();
-  let resultMsg = `<strong>${originalInput}</strong> ${
+  let resultMsg = `${originalInput} ${
     lowerCaseStr === [...lowerCaseStr].reverse().join('') ? 'is' : 'is not'
   } a palindrome.`;
 
   const pTag = document.createElement('p');
   pTag.className = 'user-input';
-  pTag.innerHTML = resultMsg;
+  pTag.innerText = resultMsg;
   resultDiv.appendChild(pTag);
 
   // Show the result.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Please also see an email I sent to `possible-security-issue at freecodecamp dot org`.

Interpolating user input into `innerHTML` sink can lead to security issues.

This pull request changes the `innerHTML` sink to `innerText` in the Palindrome Checker project, which fixes the vulnerability.

This is my first contribution to freeCodeCamp, let me know if anything could be improved! I also wanted to extend my thanks to the freeCodeCamp team for creating such a great learning platform 🙌 
