### PR TITLE
 fix: DOM text reinterpreted as HTML leading to self-XSS

### DIFF
--- a/apps/image-search-abstraction-layer/public/imageSearch.js
+++ b/apps/image-search-abstraction-layer/public/imageSearch.js
@@ -1,63 +1,63 @@
-var urlDiv = document.getElementById("url");
-var selection = document.getElementById("selection");
-var query = document.getElementById("query");
-var page = document.getElementById("page");
-var size = document.getElementById("size");
+var urlDiv = document.getElementById('url');
+var selection = document.getElementById('selection');
+var query = document.getElementById('query');
+var page = document.getElementById('page');
+var size = document.getElementById('size');
 
 //reset input fields to blank/default on load
-selection.getElementsByTagName("option")[0].selected = "selected";
-query.value = "";
+selection.getElementsByTagName('option')[0].selected = 'selected';
+query.value = '';
 page.value = 1;
-size.getElementsByTagName("option")[0].selected = "selected";
+size.getElementsByTagName('option')[0].selected = 'selected';
 
 //enables fields based on what is selected
 function enableInputs() {
   var selected = selection.options[selection.selectedIndex].value;
 
-  if (selected == "query") {
-    query.removeAttribute("disabled");
-    page.removeAttribute("disabled");
-    size.removeAttribute("disabled");
+  if (selected == 'query') {
+    query.removeAttribute('disabled');
+    page.removeAttribute('disabled');
+    size.removeAttribute('disabled');
     updateURL();
-  } else if (selected == "recent") {
-    query.setAttribute("disabled", "true");
-    page.setAttribute("disabled", "true");
-    size.setAttribute("disabled", "true");
+  } else if (selected == 'recent') {
+    query.setAttribute('disabled', 'true');
+    page.setAttribute('disabled', 'true');
+    size.setAttribute('disabled', 'true');
     updateURL();
   }
 }
 
 //changes the url displayed
 function updateURL() {
-  var url = "https://image-search-abstraction-layer.freecodecamp.rocks/";
+  var url = 'https://image-search-abstraction-layer.freecodecamp.rocks/';
   var selected = selection.options[selection.selectedIndex].value;
   var queryValue = query.value;
   var pageValue = page.value;
   var sizeValue = size.value;
   var queryTest = /\S/;
 
-  if (selected == "query" && queryTest.test(queryValue)) {
+  if (selected == 'query' && queryTest.test(queryValue)) {
     url +=
-      "query/" +
+      'query/' +
       encodeURIComponent(queryValue) +
-      "?page=" +
+      '?page=' +
       encodeURIComponent(pageValue);
-    if (sizeValue != "All") {
-      url += "&size=" + encodeURIComponent(sizeValue);
+    if (sizeValue != 'All') {
+      url += '&size=' + encodeURIComponent(sizeValue);
     }
   }
-  if (selected == "recent") {
-    url += "recent/";
+  if (selected == 'recent') {
+    url += 'recent/';
   }
 
   urlDiv.textContent = url;
-  urlDiv.setAttribute("href", url);
+  urlDiv.setAttribute('href', url);
 }
 
 enableInputs();
 //updateURL();
 
-selection.addEventListener("change", enableInputs);
-query.addEventListener("change", updateURL);
-page.addEventListener("change", updateURL);
-size.addEventListener("change", updateURL);
+selection.addEventListener('change', enableInputs);
+query.addEventListener('change', updateURL);
+page.addEventListener('change', updateURL);
+size.addEventListener('change', updateURL);

--- a/apps/image-search-abstraction-layer/public/imageSearch.js
+++ b/apps/image-search-abstraction-layer/public/imageSearch.js
@@ -1,59 +1,63 @@
-var urlDiv = document.getElementById('url');
-var selection = document.getElementById('selection');
-var query = document.getElementById('query');
-var page = document.getElementById('page');
-var size = document.getElementById('size');
+var urlDiv = document.getElementById("url");
+var selection = document.getElementById("selection");
+var query = document.getElementById("query");
+var page = document.getElementById("page");
+var size = document.getElementById("size");
 
 //reset input fields to blank/default on load
-selection.getElementsByTagName('option')[0].selected = 'selected';
-query.value = '';
+selection.getElementsByTagName("option")[0].selected = "selected";
+query.value = "";
 page.value = 1;
-size.getElementsByTagName('option')[0].selected = 'selected';
+size.getElementsByTagName("option")[0].selected = "selected";
 
 //enables fields based on what is selected
 function enableInputs() {
   var selected = selection.options[selection.selectedIndex].value;
 
-  if (selected == 'query') {
-    query.removeAttribute('disabled');
-    page.removeAttribute('disabled');
-    size.removeAttribute('disabled');
+  if (selected == "query") {
+    query.removeAttribute("disabled");
+    page.removeAttribute("disabled");
+    size.removeAttribute("disabled");
     updateURL();
-  } else if (selected == 'recent') {
-    query.setAttribute('disabled', 'true');
-    page.setAttribute('disabled', 'true');
-    size.setAttribute('disabled', 'true');
+  } else if (selected == "recent") {
+    query.setAttribute("disabled", "true");
+    page.setAttribute("disabled", "true");
+    size.setAttribute("disabled", "true");
     updateURL();
   }
 }
 
 //changes the url displayed
 function updateURL() {
-  var url = 'https://image-search-abstraction-layer.freecodecamp.rocks/';
+  var url = "https://image-search-abstraction-layer.freecodecamp.rocks/";
   var selected = selection.options[selection.selectedIndex].value;
   var queryValue = query.value;
   var pageValue = page.value;
   var sizeValue = size.value;
   var queryTest = /\S/;
 
-  if (selected == 'query' && queryTest.test(queryValue)) {
-    url += 'query/' + encodeURIComponent(queryValue) + '?page=' + encodeURIComponent(pageValue);
-    if (sizeValue != 'All') {
-      url += '&size=' + encodeURIComponent(sizeValue);
+  if (selected == "query" && queryTest.test(queryValue)) {
+    url +=
+      "query/" +
+      encodeURIComponent(queryValue) +
+      "?page=" +
+      encodeURIComponent(pageValue);
+    if (sizeValue != "All") {
+      url += "&size=" + encodeURIComponent(sizeValue);
     }
   }
-  if (selected == 'recent') {
-    url += 'recent/';
+  if (selected == "recent") {
+    url += "recent/";
   }
 
   urlDiv.textContent = url;
-  urlDiv.setAttribute('href', url);
+  urlDiv.setAttribute("href", url);
 }
 
 enableInputs();
 //updateURL();
 
-selection.addEventListener('change', enableInputs);
-query.addEventListener('change', updateURL);
-page.addEventListener('change', updateURL);
-size.addEventListener('change', updateURL);
+selection.addEventListener("change", enableInputs);
+query.addEventListener("change", updateURL);
+page.addEventListener("change", updateURL);
+size.addEventListener("change", updateURL);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)


<!-- Feel free to add any additional description of changes below this line -->

Please also see an email I sent to `possible-security-issue at freecodecamp dot org`.

To fix this issue, we need to ensure that any user input is properly sanitized or escaped before being used in a context where it can be interpreted as HTML. In this case, we should use `textContent` instead of `innerHTML` to avoid interpreting the text as HTML. Additionally, we should ensure that the URL is properly encoded.

- Replace `urlDiv.innerHTML = url;` with `urlDiv.textContent = url;` to prevent the text from being interpreted as HTML.
- Ensure that the URL is properly encoded using `encodeURIComponent` for the query parameters.




