### PR TITLE
Fix tooltip displaying incorrect months on Y-axis

### DIFF
--- a/apps/heat-map/public/script.js
+++ b/apps/heat-map/public/script.js
@@ -386,7 +386,7 @@ function callback(data) {
       return legendThreshold(data.baseTemperature + d.variance);
     })
     .on('mouseover', function (event, d) {
-      var date = new Date(d.year, d.month);
+      var date = new Date(d.year, d.month + 1);
       var str =
         "<span class='date'>" +
         d3.utcFormat('%Y - %B')(date) +


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #611 

<!-- Feel free to add any additional description of changes below this line -->

### Summary:
This PR fixes an issue where the tooltip was displaying incorrect months for the corresponding data points on the Y-axis.

- **Months on the Y-axis**: The tooltip was showing the wrong month values for the data points on the Y-axis. This issue has been addressed, and the correct month is now displayed for each data point.

### Changes:
- Updated the tooltip logic to correctly reflect the month corresponding to the Y-axis value.

### Impact:
This fix ensures that the tooltip now accurately displays the correct month for the data points on the Y-axis.

### Testing:
- Manually tested the tooltip for all data points on the Y-axis.
- Verified that the correct month is now displayed in the tooltip for the Y-axis values.
